### PR TITLE
fix: Navbar should close when user clicks an option #2081 clappr/clap…

### DIFF
--- a/clappr-custom.js
+++ b/clappr-custom.js
@@ -1,0 +1,12 @@
+$(document).ready(function () {
+  $(".clappr-ws__menu-link").on("click", function () {
+    $(".clappr-ws__menu-list").attr("style", ""),
+      setTimeout(function () {
+        $(".clappr-ws__side-menu").attr("style", ""),
+          $(".clappr-ws__menu").attr("style", "width: 0vw;"),
+          setTimeout(function () {
+            $(".clappr-ws__open-menu").addClass("none");
+          }, 500);
+      }, 100);
+  });
+});

--- a/index.html
+++ b/index.html
@@ -296,6 +296,9 @@
           <circle fill="#FFFFFF" cx="30" cy="30" r="30"/>
         </svg>
     </div>
+
+    <script type="text/javascript" src="clappr-custom.js"></script>
     <script src="http://cdnjs.cloudflare.com/ajax/libs/ScrollMagic/2.0.5/ScrollMagic.min.js"></script>
   </body>
 </html>
+


### PR DESCRIPTION
Resolve the issue of clicking at options at the side menu while the menu not closing after, resulting in bad user experience at http://clappr.io

Done by adding a new custom js script, which selects any items which has the menu option class and executes the closing of menu.

![image](https://user-images.githubusercontent.com/81701584/213026529-7f5d4c84-24c8-4c78-9a5f-f20e53106c70.png)
